### PR TITLE
CM-25038 - Run IaC scanning asynchronously using polling mechanism

### DIFF
--- a/cycode/cli/code_scanner.py
+++ b/cycode/cli/code_scanner.py
@@ -549,9 +549,6 @@ def perform_scan(
     if is_commit_range:
         return cycode_client.commit_range_zipped_file_scan(scan_type, zipped_documents, scan_id)
 
-    if scan_type == consts.INFRA_CONFIGURATION_SCAN_TYPE:
-        return cycode_client.zipped_file_scan(scan_type, zipped_documents, scan_id, scan_parameters, is_git_diff)
-
     return perform_scan_async(cycode_client, zipped_documents, scan_type, scan_parameters)
 
 

--- a/cycode/cyclient/scan_config_base.py
+++ b/cycode/cyclient/scan_config_base.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from cycode.cli import consts
+
 
 class ScanConfigBase(ABC):
     @abstractmethod
@@ -17,9 +19,10 @@ class ScanConfigBase(ABC):
 
     @staticmethod
     def get_async_entity_type(scan_type: str) -> str:
-        if scan_type == 'secret':
+        if scan_type in {consts.SECRET_SCAN_TYPE, consts.INFRA_CONFIGURATION_SCAN_TYPE}:
             return 'zippedfile'
 
+        # TODO(MarshalX): SAST, SCA is not migrated to new endpoint yet
         return 'repository'
 
     @abstractmethod


### PR DESCRIPTION
draft for now. the `is_git_diff` flag is gone. need to verify IaC pre-commit hook scans and commit range scans. also need to try to reproduce fixed bugs from secrets migration to async scans 