### PR TITLE
CM-35811 - Change GitHub Actions runner for building CLI for ARM macOS

### DIFF
--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -143,6 +143,7 @@ jobs:
       - name: Test macOS signed executable
         if: runner.os == 'macOS'
         run: |
+          file -b $PATH_TO_CYCODE_CLI_EXECUTABLE
           time $PATH_TO_CYCODE_CLI_EXECUTABLE version
 
           # verify signature

--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -2,6 +2,7 @@ name: Build executable version of CLI and upload artifact. On dispatch event bui
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main
@@ -15,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-11, macos-13-xlarge, windows-2019 ]
+        os: [ ubuntu-20.04, macos-11, macos-14, windows-2019 ]
         mode: [ 'onefile', 'onedir' ]
         exclude:
           - os: ubuntu-20.04

--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-13, macos-14, windows-2019 ]
+        os: [ ubuntu-20.04, macos-12, macos-14, windows-2019 ]
         mode: [ 'onefile', 'onedir' ]
         exclude:
           - os: ubuntu-20.04

--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -2,7 +2,6 @@ name: Build executable version of CLI and upload artifact. On dispatch event bui
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-11, macos-14, windows-2019 ]
+        os: [ ubuntu-20.04, macos-13, macos-14, windows-2019 ]
         mode: [ 'onefile', 'onedir' ]
         exclude:
           - os: ubuntu-20.04


### PR DESCRIPTION
i ve bumped runner for x86_64 because 

> The macos-11 label has been deprecated and will no longer be available after 6/28/2024. 