### PR TITLE
CM-30526 - Make Git executable optional

### DIFF
--- a/cycode/cli/commands/scan/pre_commit/pre_commit_command.py
+++ b/cycode/cli/commands/scan/pre_commit/pre_commit_command.py
@@ -2,7 +2,6 @@ import os
 from typing import List
 
 import click
-from git import Repo
 
 from cycode.cli import consts
 from cycode.cli.commands.scan.code_scanner import scan_documents, scan_sca_pre_commit
@@ -12,6 +11,7 @@ from cycode.cli.files_collector.repository_documents import (
     get_diff_file_path,
 )
 from cycode.cli.models import Document
+from cycode.cli.utils.git_proxy import git_proxy
 from cycode.cli.utils.path_utils import (
     get_path_by_os,
 )
@@ -31,7 +31,7 @@ def pre_commit_command(context: click.Context, ignored_args: List[str]) -> None:
         scan_sca_pre_commit(context)
         return
 
-    diff_files = Repo(os.getcwd()).index.diff('HEAD', create_patch=True, R=True)
+    diff_files = git_proxy.get_repo(os.getcwd()).index.diff('HEAD', create_patch=True, R=True)
 
     progress_bar.set_section_length(ScanProgressBarSection.PREPARE_LOCAL_FILES, len(diff_files))
 

--- a/cycode/cli/exceptions/handle_scan_errors.py
+++ b/cycode/cli/exceptions/handle_scan_errors.py
@@ -1,11 +1,11 @@
 from typing import Optional
 
 import click
-from git import InvalidGitRepositoryError
 
 from cycode.cli.exceptions import custom_exceptions
 from cycode.cli.models import CliError, CliErrors
 from cycode.cli.printers import ConsolePrinter
+from cycode.cli.utils.git_proxy import git_proxy
 
 
 def handle_scan_exception(
@@ -49,7 +49,7 @@ def handle_scan_exception(
             'Please make sure that your file is well formed '
             'and execute the scan again',
         ),
-        InvalidGitRepositoryError: CliError(
+        git_proxy.get_invalid_git_repository_error(): CliError(
             soft_fail=False,
             code='invalid_git_error',
             message='The path you supplied does not correlate to a git repository. '

--- a/cycode/cli/exceptions/handle_scan_errors.py
+++ b/cycode/cli/exceptions/handle_scan_errors.py
@@ -13,7 +13,7 @@ def handle_scan_exception(
 ) -> Optional[CliError]:
     context.obj['did_fail'] = True
 
-    ConsolePrinter(context).print_exception()
+    ConsolePrinter(context).print_exception(e)
 
     errors: CliErrors = {
         custom_exceptions.NetworkError: CliError(
@@ -69,10 +69,13 @@ def handle_scan_exception(
         ConsolePrinter(context).print_error(error)
         return None
 
+    unknown_error = CliError(code='unknown_error', message=str(e))
+
     if return_exception:
-        return CliError(code='unknown_error', message=str(e))
+        return unknown_error
 
     if isinstance(e, click.ClickException):
         raise e
 
-    raise click.ClickException(str(e))
+    ConsolePrinter(context).print_error(unknown_error)
+    exit(1)

--- a/cycode/cli/printers/printer_base.py
+++ b/cycode/cli/printers/printer_base.py
@@ -43,7 +43,7 @@ class PrinterBase(ABC):
             # gets the most recent exception caught by an except clause
             message = f'Error: {traceback.format_exc()}'
         else:
-            traceback_message = ''.join(traceback.format_exception(e))
+            traceback_message = ''.join(traceback.format_exception(None, e, e.__traceback__))
             message = f'Error: {traceback_message}'
 
         click.secho(message, err=True, fg=self.RED_COLOR_NAME)

--- a/cycode/cli/utils/git_proxy.py
+++ b/cycode/cli/utils/git_proxy.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from functools import cache
+from functools import lru_cache
 from typing import TYPE_CHECKING, Optional, Type
 
 _GIT_ERROR_MESSAGE = """
@@ -62,7 +62,7 @@ class _GitProxy(_AbstractGitProxy):
     def get_null_tree(self) -> object:
         return git.NULL_TREE
 
-    @cache  # noqa: B019
+    @lru_cache(maxsize=None)  # noqa: B019
     def get_invalid_git_repository_error(self) -> Type[GitProxyError]:
         # we must cache it because we want to return the same class every time
         class InvalidGitRepositoryError(GitProxyError, git.InvalidGitRepositoryError):
@@ -70,7 +70,7 @@ class _GitProxy(_AbstractGitProxy):
 
         return InvalidGitRepositoryError
 
-    @cache  # noqa: B019
+    @lru_cache(maxsize=None)  # noqa: B019
     def get_git_command_error(self) -> Type[GitProxyError]:
         # we must cache it because we want to return the same class every time
         class GitCommandError(GitProxyError, git.GitCommandError):

--- a/cycode/cli/utils/git_proxy.py
+++ b/cycode/cli/utils/git_proxy.py
@@ -7,7 +7,7 @@ Cycode CLI needs the git executable to be installed on the system.
 Git executable must be available in the PATH.
 Git 1.7.x or newer is required.
 You can help Cycode CLI to locate the Git executable
-by setting GIT_PYTHON_GIT_EXECUTABLE=<path/to/git> environment variable.
+by setting the GIT_PYTHON_GIT_EXECUTABLE=<path/to/git> environment variable.
 """.strip().replace('\n', ' ')
 
 try:

--- a/cycode/cli/utils/git_proxy.py
+++ b/cycode/cli/utils/git_proxy.py
@@ -1,0 +1,82 @@
+from abc import ABC, abstractmethod
+from functools import cache
+from typing import TYPE_CHECKING, Optional, Type
+
+_GIT_ERROR_MESSAGE = """
+Cycode CLI needs the git executable to be installed on the system.
+Git executable must be available in the PATH.
+Git 1.7.x or newer is required.
+You can help Cycode CLI to locate the Git executable
+by setting GIT_PYTHON_GIT_EXECUTABLE=<path/to/git> environment variable.
+""".strip().replace('\n', ' ')
+
+try:
+    import git
+except ImportError:
+    git = None
+
+if TYPE_CHECKING:
+    from git import PathLike, Repo
+
+
+class GitProxyError(Exception):
+    pass
+
+
+class _AbstractGitProxy(ABC):
+    @abstractmethod
+    def get_repo(self, path: Optional['PathLike'] = None) -> 'Repo':
+        ...
+
+    @abstractmethod
+    def get_null_tree(self) -> object:
+        ...
+
+    @abstractmethod
+    def get_invalid_git_repository_error(self) -> Type[GitProxyError]:
+        ...
+
+    @abstractmethod
+    def get_git_command_error(self) -> Type[GitProxyError]:
+        ...
+
+
+class _DummyGitProxy(_AbstractGitProxy):
+    def get_repo(self, path: Optional['PathLike'] = None) -> 'Repo':
+        raise RuntimeError(_GIT_ERROR_MESSAGE)
+
+    def get_null_tree(self) -> object:
+        return object()
+
+    def get_invalid_git_repository_error(self) -> Type[GitProxyError]:
+        return GitProxyError
+
+    def get_git_command_error(self) -> Type[GitProxyError]:
+        return GitProxyError
+
+
+class _GitProxy(_AbstractGitProxy):
+    def get_repo(self, path: Optional['PathLike'] = None) -> 'Repo':
+        return git.Repo(path)
+
+    def get_null_tree(self) -> object:
+        return git.NULL_TREE
+
+    @cache  # noqa: B019
+    def get_invalid_git_repository_error(self) -> Type[GitProxyError]:
+        # we must cache it because we want to return the same class every time
+        class InvalidGitRepositoryError(GitProxyError, git.InvalidGitRepositoryError):
+            ...
+
+        return InvalidGitRepositoryError
+
+    @cache  # noqa: B019
+    def get_git_command_error(self) -> Type[GitProxyError]:
+        # we must cache it because we want to return the same class every time
+        class GitCommandError(GitProxyError, git.GitCommandError):
+            ...
+
+        return GitCommandError
+
+
+git_proxy = _GitProxy() if git else _DummyGitProxy()

--- a/cycode/cli/utils/git_proxy.py
+++ b/cycode/cli/utils/git_proxy.py
@@ -63,11 +63,9 @@ class _GitProxy(_AbstractGitProxy):
         return git.NULL_TREE
 
     def get_invalid_git_repository_error(self) -> Type[BaseException]:
-        # we must cache it because we want to return the same class every time
         return git.InvalidGitRepositoryError
 
     def get_git_command_error(self) -> Type[BaseException]:
-        # we must cache it because we want to return the same class every time
         return git.GitCommandError
 
 

--- a/tests/cli/exceptions/test_handle_scan_errors.py
+++ b/tests/cli/exceptions/test_handle_scan_errors.py
@@ -40,7 +40,7 @@ def test_handle_exception_soft_fail(
 
 
 def test_handle_exception_unhandled_error(ctx: click.Context) -> None:
-    with ctx, pytest.raises(ClickException):
+    with ctx, pytest.raises(SystemExit):
         handle_scan_exception(ctx, ValueError('test'))
 
         assert ctx.obj.get('did_fail') is True
@@ -58,10 +58,12 @@ def test_handle_exception_click_error(ctx: click.Context) -> None:
 def test_handle_exception_verbose(monkeypatch: 'MonkeyPatch') -> None:
     ctx = click.Context(click.Command('path'), obj={'verbose': True, 'output': 'text'})
 
+    error_text = 'test'
+
     def mock_secho(msg: str, *_, **__) -> None:
-        assert 'Error:' in msg or 'Correlation ID:' in msg
+        assert error_text in msg or 'Correlation ID:' in msg
 
     monkeypatch.setattr(click, 'secho', mock_secho)
 
-    with ctx, pytest.raises(ClickException):
-        handle_scan_exception(ctx, ValueError('test'))
+    with pytest.raises(SystemExit):
+        handle_scan_exception(ctx, ValueError(error_text))

--- a/tests/cli/exceptions/test_handle_scan_errors.py
+++ b/tests/cli/exceptions/test_handle_scan_errors.py
@@ -3,11 +3,11 @@ from typing import TYPE_CHECKING
 import click
 import pytest
 from click import ClickException
-from git import InvalidGitRepositoryError
 from requests import Response
 
 from cycode.cli.exceptions import custom_exceptions
 from cycode.cli.exceptions.handle_scan_errors import handle_scan_exception
+from cycode.cli.utils.git_proxy import git_proxy
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -26,7 +26,7 @@ def ctx() -> click.Context:
         (custom_exceptions.HttpUnauthorizedError('msg', Response()), True),
         (custom_exceptions.ZipTooLargeError(1000), True),
         (custom_exceptions.TfplanKeyError('msg'), True),
-        (InvalidGitRepositoryError(), None),
+        (git_proxy.get_invalid_git_repository_error()(), None),
     ],
 )
 def test_handle_exception_soft_fail(

--- a/tests/utils/test_git_proxy.py
+++ b/tests/utils/test_git_proxy.py
@@ -1,0 +1,53 @@
+import os
+import tempfile
+
+import git as real_git
+import pytest
+
+from cycode.cli.utils.git_proxy import _GIT_ERROR_MESSAGE, GitProxyError, _DummyGitProxy, _GitProxy, get_git_proxy
+
+
+def test_get_git_proxy() -> None:
+    proxy = get_git_proxy(git_module=None)
+    assert isinstance(proxy, _DummyGitProxy)
+
+    proxy2 = get_git_proxy(git_module=real_git)
+    assert isinstance(proxy2, _GitProxy)
+
+
+def test_dummy_git_proxy() -> None:
+    proxy = _DummyGitProxy()
+
+    with pytest.raises(RuntimeError) as exc:
+        proxy.get_repo()
+    assert str(exc.value) == _GIT_ERROR_MESSAGE
+
+    with pytest.raises(RuntimeError) as exc2:
+        proxy.get_null_tree()
+    assert str(exc2.value) == _GIT_ERROR_MESSAGE
+
+    assert proxy.get_git_command_error() is GitProxyError
+    assert proxy.get_invalid_git_repository_error() is GitProxyError
+
+
+def test_git_proxy() -> None:
+    proxy = _GitProxy()
+
+    repo = proxy.get_repo(os.getcwd(), search_parent_directories=True)
+    assert isinstance(repo, real_git.Repo)
+
+    assert proxy.get_null_tree() is real_git.NULL_TREE
+
+    assert proxy.get_git_command_error() is real_git.GitCommandError
+    assert proxy.get_invalid_git_repository_error() is real_git.InvalidGitRepositoryError
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(real_git.InvalidGitRepositoryError):
+            proxy.get_repo(tmpdir)
+        with pytest.raises(proxy.get_invalid_git_repository_error()):
+            proxy.get_repo(tmpdir)
+
+    with pytest.raises(real_git.GitCommandError):
+        repo.git.show('blabla')
+    with pytest.raises(proxy.get_git_command_error()):
+        repo.git.show('blabla')


### PR DESCRIPTION
idea: we don't need to work with git in all cases. for example, path scans could be executed without depending on git. git used to get commit history and so on.

how does it work: GitPython on import tries to find and verify git executable installed in the system. it raises an exception if it can't be found. we can catch this exception and provide a fake git provider, which will throw exceptions only on specific function calls instead of on the module import. all type hints from git module are hidden behind TYPE_CHECKING var

also, these exceptions go via our printers and depend on --output format now (json support for IDE plugins)