### PR TITLE
CM-41830 - Fix generating and uploading attestations to PyPI

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -25,6 +25,7 @@ jobs:
             install.python-poetry.org
             pypi.org
             upload.pypi.org
+            *.sigstore.dev
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
             install.python-poetry.org
             pypi.org
             upload.pypi.org
+            *.sigstore.dev
 
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
they made it enabled by default week ago
release - https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.11.0
docs -  https://github.com/marketplace/actions/pypi-publish#generating-and-uploading-attestations