### PR TITLE
CM-46370 - Add the error message from the server responses to the user space

### DIFF
--- a/cycode/cli/apps/ignore/ignore_command.py
+++ b/cycode/cli/apps/ignore/ignore_command.py
@@ -57,7 +57,7 @@ def ignore_command(  # noqa: C901
     by_package: Annotated[
         Optional[str],
         typer.Option(
-            help='Ignore scanning a specific package version. Expected pattern: [cyan]name@version[/cyan].',
+            help='Ignore scanning a specific package version. Expected pattern: [cyan]name@version[/].',
             show_default=False,
             rich_help_panel=_SCA_FILTER_BY_RICH_HELP_PANEL,
         ),
@@ -65,7 +65,7 @@ def ignore_command(  # noqa: C901
     by_cve: Annotated[
         Optional[str],
         typer.Option(
-            help='Ignore scanning a specific CVE. Expected pattern: [cyan]CVE-YYYY-NNN[/cyan].',
+            help='Ignore scanning a specific CVE. Expected pattern: [cyan]CVE-YYYY-NNN[/].',
             show_default=False,
             rich_help_panel=_SCA_FILTER_BY_RICH_HELP_PANEL,
         ),

--- a/cycode/cli/apps/scan/code_scanner.py
+++ b/cycode/cli/apps/scan/code_scanner.py
@@ -649,7 +649,7 @@ def _get_default_scan_parameters(ctx: typer.Context) -> dict:
         'report': ctx.obj.get('report'),
         'package_vulnerabilities': ctx.obj.get('package-vulnerabilities'),
         'license_compliance': ctx.obj.get('license-compliance'),
-        'command_type': ctx.info_name,
+        'command_type': ctx.info_name.replace('-', '_'),  # save backward compatibility
         'aggregation_id': str(_generate_unique_id()),
     }
 

--- a/cycode/cli/apps/scan/scan_command.py
+++ b/cycode/cli/apps/scan/scan_command.py
@@ -83,8 +83,7 @@ def scan_command(
         bool,
         typer.Option(
             '--no-restore',
-            help='When specified, Cycode will not run restore command. '
-            'Will scan direct dependencies [bold]only[/bold]!',
+            help='When specified, Cycode will not run restore command. ' 'Will scan direct dependencies [b]only[/]!',
             rich_help_panel=_SCA_RICH_HELP_PANEL,
         ),
     ] = False,
@@ -93,14 +92,14 @@ def scan_command(
         typer.Option(
             '--gradle-all-sub-projects',
             help='When specified, Cycode will run gradle restore command for all sub projects. '
-            'Should run from root project directory [bold]only[/bold]!',
+            'Should run from root project directory [b]only[/]!',
             rich_help_panel=_SCA_RICH_HELP_PANEL,
         ),
     ] = False,
 ) -> None:
     """:magnifying_glass_tilted_right: Scan the content for Secrets, IaC, SCA, and SAST violations.
     You'll need to specify which scan type to perform:
-    [cyan]path[/cyan]/[cyan]repository[/cyan]/[cyan]commit_history[/cyan]."""
+    [cyan]path[/]/[cyan]repository[/]/[cyan]commit_history[/]."""
     add_breadcrumb('scan')
 
     ctx.obj['show_secret'] = show_secret

--- a/cycode/cli/apps/status/version_command.py
+++ b/cycode/cli/apps/status/version_command.py
@@ -5,6 +5,6 @@ from cycode.cli.console import console
 
 
 def version_command(ctx: typer.Context) -> None:
-    console.print('[yellow][bold]This command is deprecated. Please use the "status" command instead.[/bold][/yellow]')
+    console.print('[b yellow]This command is deprecated. Please use the "status" command instead.[/]')
     console.print()  # print an empty line
     status_command(ctx)

--- a/cycode/cli/cli_types.py
+++ b/cycode/cli/cli_types.py
@@ -57,7 +57,7 @@ class SeverityOption(str, Enum):
 
     def __rich__(self) -> str:
         color = self.get_member_color(self.value)
-        return f'[{color}]{self.value.upper()}[/{color}]'
+        return f'[{color}]{self.value.upper()}[/]'
 
 
 _SEVERITY_DEFAULT_WEIGHT = -1

--- a/cycode/cli/exceptions/custom_exceptions.py
+++ b/cycode/cli/exceptions/custom_exceptions.py
@@ -6,6 +6,10 @@ from cycode.cli.models import CliError, CliErrors
 class CycodeError(Exception):
     """Base class for all custom exceptions"""
 
+    def __str__(self) -> str:
+        class_name = self.__class__.__name__
+        return f'{class_name} error occurred.'
+
 
 class RequestError(CycodeError): ...
 
@@ -27,10 +31,7 @@ class RequestHttpError(RequestError):
         super().__init__(self.error_message)
 
     def __str__(self) -> str:
-        return (
-            f'error occurred during the request. status code: {self.status_code}, error message: '
-            f'{self.error_message}'
-        )
+        return f'HTTP error occurred during the request (code {self.status_code}). Message: {self.error_message}'
 
 
 class ScanAsyncError(CycodeError):
@@ -39,7 +40,7 @@ class ScanAsyncError(CycodeError):
         super().__init__(self.error_message)
 
     def __str__(self) -> str:
-        return f'error occurred during the scan. error message: {self.error_message}'
+        return f'Async scan error occurred during the scan. Message: {self.error_message}'
 
 
 class ReportAsyncError(CycodeError):
@@ -54,7 +55,7 @@ class HttpUnauthorizedError(RequestError):
         super().__init__(self.error_message)
 
     def __str__(self) -> str:
-        return 'Http Unauthorized Error'
+        return f'HTTP unauthorized error occurred during the request. Message: {self.error_message}'
 
 
 class ZipTooLargeError(CycodeError):
@@ -72,7 +73,7 @@ class AuthProcessError(CycodeError):
         super().__init__()
 
     def __str__(self) -> str:
-        return f'Something went wrong during the authentication process, error message: {self.error_message}'
+        return f'Something went wrong during the authentication process. Message: {self.error_message}'
 
 
 class TfplanKeyError(CycodeError):
@@ -106,6 +107,6 @@ KNOWN_USER_FRIENDLY_REQUEST_ERRORS: CliErrors = {
         code='ssl_error',
         message='An SSL error occurred when trying to connect to the Cycode API. '
         'If you use an on-premises installation or a proxy that intercepts SSL traffic '
-        'you should use the CURL_CA_BUNDLE environment variable to specify path to a valid .pem or similar.',
+        'you should use the CURL_CA_BUNDLE environment variable to specify path to a valid .pem or similar',
     ),
 }

--- a/cycode/cli/exceptions/handle_errors.py
+++ b/cycode/cli/exceptions/handle_errors.py
@@ -14,7 +14,7 @@ def handle_errors(
     ConsolePrinter(ctx).print_exception(err)
 
     if type(err) in cli_errors:
-        error = cli_errors[type(err)]
+        error = cli_errors[type(err)].enrich(additional_message=str(err))
 
         if error.soft_fail is True:
             ctx.obj['soft_fail'] = True

--- a/cycode/cli/models.py
+++ b/cycode/cli/models.py
@@ -37,6 +37,10 @@ class CliError(NamedTuple):
     message: str
     soft_fail: bool = False
 
+    def enrich(self, additional_message: str) -> 'CliError':
+        message = f'{self.message} ({additional_message})'
+        return CliError(self.code, message, self.soft_fail)
+
 
 CliErrors = Dict[Type[BaseException], CliError]
 

--- a/cycode/cli/printers/printer_base.py
+++ b/cycode/cli/printers/printer_base.py
@@ -17,11 +17,11 @@ from rich.traceback import Traceback as RichTraceback
 
 class PrinterBase(ABC):
     NO_DETECTIONS_MESSAGE = (
-        '[green]Good job! No issues were found!!! :clapping_hands::clapping_hands::clapping_hands:[/green]'
+        '[green]Good job! No issues were found!!! :clapping_hands::clapping_hands::clapping_hands:[/]'
     )
     FAILED_SCAN_MESSAGE = (
         '[red]Unfortunately, Cycode was unable to complete the full scan. '
-        'Please note that not all results may be available:[/red]'
+        'Please note that not all results may be available:[/]'
     )
 
     def __init__(self, ctx: typer.Context) -> None:
@@ -56,4 +56,4 @@ class PrinterBase(ABC):
         rich_traceback.show_locals = False
         console_err.print(rich_traceback)
 
-        console_err.print(f'[red]Correlation ID:[/red] {get_correlation_id()}')
+        console_err.print(f'[red]Correlation ID:[/] {get_correlation_id()}')

--- a/cycode/cli/printers/tables/sca_table_printer.py
+++ b/cycode/cli/printers/tables/sca_table_printer.py
@@ -178,7 +178,7 @@ class ScaTablePrinter(TablePrinterBase):
 
     @staticmethod
     def _print_summary_issues(detections_count: int, title: str) -> None:
-        console.print(f':no_entry: Found {detections_count} issues of type: [bold]{title}[/bold]')
+        console.print(f':no_entry: Found {detections_count} issues of type: [b]{title}[/]')
 
     @staticmethod
     def _extract_detections_per_policy_id(

--- a/cycode/cli/printers/tables/table.py
+++ b/cycode/cli/printers/tables/table.py
@@ -28,7 +28,7 @@ class Table:
 
     def add_cell(self, column: 'ColumnInfo', value: str, color: Optional[str] = None) -> None:
         if color:
-            value = f'[{color}]{value}[/{color}]'
+            value = f'[{color}]{value}[/]'
 
         self._add_cell_no_error(column, value)
 

--- a/cycode/cli/printers/text_printer.py
+++ b/cycode/cli/printers/text_printer.py
@@ -39,7 +39,7 @@ class TextPrinter(PrinterBase):
             console.print(f'- {name}: {value}', style=color)
 
     def print_error(self, error: CliError) -> None:
-        console.print(f'[red]Error: {error.message}[/red]')
+        console.print(f'[red]Error: {error.message}[/]', highlight=False)
 
     def print_scan_results(
         self, local_scan_results: List['LocalScanResult'], errors: Optional[Dict[str, 'CliError']] = None
@@ -91,7 +91,7 @@ class TextPrinter(PrinterBase):
         console.print(
             ':no_entry: Found',
             severity,
-            f'issue of type: [bright_red][bold]{name}[/bold][/bright_red] '
+            f'issue of type: [b bright_red]{name}[/] '
             f'in file: {clickable_document_path} '
             f'{detection_commit_id_message}'
             f'{company_guidelines_message}'

--- a/cycode/cli/utils/version_checker.py
+++ b/cycode/cli/utils/version_checker.py
@@ -198,9 +198,9 @@ class VersionChecker(CycodeClientBase):
         if should_update:
             update_message = (
                 '\nNew version of cycode available! '
-                f'[yellow]{current_version}[/yellow] → [bright_blue]{latest_version}[/bright_blue]\n'
-                f'Changelog: [bright_blue]{self.GIT_CHANGELOG_URL_PREFIX}{latest_version}[/bright_blue]\n'
-                f'Run [green]pip install --upgrade cycode[/green] to update\n'
+                f'[yellow]{current_version}[/] → [bright_blue]{latest_version}[/]\n'
+                f'Changelog: [bright_blue]{self.GIT_CHANGELOG_URL_PREFIX}{latest_version}[/]\n'
+                f'Run [green]pip install --upgrade cycode[/] to update\n'
             )
             console.print(update_message)
 


### PR DESCRIPTION
now it will tell why the scan failed. for example because of `HTTP error occurred during the request (code 400). Message: Scan type is not supported: SAST`