### PR TITLE
CM-46733 - Add CLI output exporting in HTML, SVG, and JSON formats

### DIFF
--- a/cycode/cli/app.py
+++ b/cycode/cli/app.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Annotated, Optional
 
 import typer
@@ -6,8 +7,9 @@ from typer.completion import install_callback, show_callback
 
 from cycode import __version__
 from cycode.cli.apps import ai_remediation, auth, configure, ignore, report, scan, status
-from cycode.cli.cli_types import OutputTypeOption
+from cycode.cli.cli_types import ExportTypeOption, OutputTypeOption
 from cycode.cli.consts import CLI_CONTEXT_SETTINGS
+from cycode.cli.printers import ConsolePrinter
 from cycode.cli.user_settings.configuration_manager import ConfigurationManager
 from cycode.cli.utils.progress_bar import SCAN_PROGRESS_BAR_SECTIONS, get_progress_bar
 from cycode.cli.utils.sentry import add_breadcrumb, init_sentry
@@ -44,7 +46,14 @@ def check_latest_version_on_close(ctx: typer.Context) -> None:
     version_checker.check_and_notify_update(current_version=__version__, use_cache=should_use_cache)
 
 
+def export_if_needed_on_close(ctx: typer.Context) -> None:
+    printer = ctx.obj.get('console_printer')
+    if printer.is_recording:
+        printer.export()
+
+
 _COMPLETION_RICH_HELP_PANEL = 'Completion options'
+_EXPORT_RICH_HELP_PANEL = 'Export options'
 
 
 @app.callback()
@@ -63,6 +72,27 @@ def app_callback(
     user_agent: Annotated[
         Optional[str],
         typer.Option(hidden=True, help='Characteristic JSON object that lets servers identify the application.'),
+    ] = None,
+    export_type: Annotated[
+        ExportTypeOption,
+        typer.Option(
+            '--export-type',
+            case_sensitive=False,
+            help='Specify the export type. '
+            'HTML and SVG will export terminal output and rely on --output option. '
+            'JSON always exports JSON.',
+            rich_help_panel=_EXPORT_RICH_HELP_PANEL,
+        ),
+    ] = ExportTypeOption.JSON,
+    export_file: Annotated[
+        Optional[Path],
+        typer.Option(
+            '--export-file',
+            help='Export file. Path to the file where the export will be saved. ',
+            dir_okay=False,
+            writable=True,
+            rich_help_panel=_EXPORT_RICH_HELP_PANEL,
+        ),
     ] = None,
     _: Annotated[
         Optional[bool],
@@ -103,6 +133,11 @@ def app_callback(
         no_progress_meter = True
 
     ctx.obj['progress_bar'] = get_progress_bar(hidden=no_progress_meter, sections=SCAN_PROGRESS_BAR_SECTIONS)
+
+    ctx.obj['export_type'] = export_type
+    ctx.obj['export_file'] = export_file
+    ctx.obj['console_printer'] = ConsolePrinter(ctx)
+    ctx.call_on_close(lambda: export_if_needed_on_close(ctx))
 
     if user_agent:
         user_agent_option = UserAgentOptionScheme().loads(user_agent)

--- a/cycode/cli/apps/ai_remediation/apply_fix.py
+++ b/cycode/cli/apps/ai_remediation/apply_fix.py
@@ -4,11 +4,10 @@ import typer
 from patch_ng import fromstring
 
 from cycode.cli.models import CliResult
-from cycode.cli.printers import ConsolePrinter
 
 
 def apply_fix(ctx: typer.Context, diff: str, is_fix_available: bool) -> None:
-    printer = ConsolePrinter(ctx)
+    printer = ctx.obj.get('console_printer')
     if not is_fix_available:
         printer.print_result(CliResult(success=False, message='Fix is not available for this violation'))
         return

--- a/cycode/cli/apps/ai_remediation/print_remediation.py
+++ b/cycode/cli/apps/ai_remediation/print_remediation.py
@@ -3,11 +3,10 @@ from rich.markdown import Markdown
 
 from cycode.cli.console import console
 from cycode.cli.models import CliResult
-from cycode.cli.printers import ConsolePrinter
 
 
 def print_remediation(ctx: typer.Context, remediation_markdown: str, is_fix_available: bool) -> None:
-    printer = ConsolePrinter(ctx)
+    printer = ctx.obj.get('console_printer')
     if printer.is_json_printer:
         data = {'remediation': remediation_markdown, 'is_fix_available': is_fix_available}
         printer.print_result(CliResult(success=True, message='Remediation fetched successfully', data=data))

--- a/cycode/cli/apps/auth/auth_command.py
+++ b/cycode/cli/apps/auth/auth_command.py
@@ -4,13 +4,13 @@ from cycode.cli.apps.auth.auth_manager import AuthManager
 from cycode.cli.exceptions.handle_auth_errors import handle_auth_exception
 from cycode.cli.logger import logger
 from cycode.cli.models import CliResult
-from cycode.cli.printers import ConsolePrinter
 from cycode.cli.utils.sentry import add_breadcrumb
 
 
 def auth_command(ctx: typer.Context) -> None:
     """Authenticates your machine."""
     add_breadcrumb('auth')
+    printer = ctx.obj.get('console_printer')
 
     if ctx.invoked_subcommand is not None:
         # if it is a subcommand, do nothing
@@ -23,6 +23,6 @@ def auth_command(ctx: typer.Context) -> None:
         auth_manager.authenticate()
 
         result = CliResult(success=True, message='Successfully logged into cycode')
-        ConsolePrinter(ctx).print_result(result)
+        printer.print_result(result)
     except Exception as err:
         handle_auth_exception(ctx, err)

--- a/cycode/cli/apps/auth/auth_common.py
+++ b/cycode/cli/apps/auth/auth_common.py
@@ -4,13 +4,14 @@ import typer
 
 from cycode.cli.apps.auth.models import AuthInfo
 from cycode.cli.exceptions.custom_exceptions import HttpUnauthorizedError, RequestHttpError
-from cycode.cli.printers import ConsolePrinter
 from cycode.cli.user_settings.credentials_manager import CredentialsManager
 from cycode.cli.utils.jwt_utils import get_user_and_tenant_ids_from_access_token
 from cycode.cyclient.cycode_token_based_client import CycodeTokenBasedClient
 
 
 def get_authorization_info(ctx: Optional[typer.Context] = None) -> Optional[AuthInfo]:
+    printer = ctx.obj.get('console_printer')
+
     client_id, client_secret = CredentialsManager().get_credentials()
     if not client_id or not client_secret:
         return None
@@ -24,6 +25,6 @@ def get_authorization_info(ctx: Optional[typer.Context] = None) -> Optional[Auth
         return AuthInfo(user_id=user_id, tenant_id=tenant_id)
     except (RequestHttpError, HttpUnauthorizedError):
         if ctx:
-            ConsolePrinter(ctx).print_exception()
+            printer.print_exception()
 
         return None

--- a/cycode/cli/apps/auth/check_command.py
+++ b/cycode/cli/apps/auth/check_command.py
@@ -2,7 +2,6 @@ import typer
 
 from cycode.cli.apps.auth.auth_common import get_authorization_info
 from cycode.cli.models import CliResult
-from cycode.cli.printers import ConsolePrinter
 from cycode.cli.utils.sentry import add_breadcrumb
 
 
@@ -10,7 +9,7 @@ def check_command(ctx: typer.Context) -> None:
     """Checks that your machine is associating the CLI with your Cycode account."""
     add_breadcrumb('check')
 
-    printer = ConsolePrinter(ctx)
+    printer = ctx.obj.get('console_printer')
     auth_info = get_authorization_info(ctx)
     if auth_info is None:
         printer.print_result(CliResult(success=False, message='Cycode authentication failed'))

--- a/cycode/cli/apps/scan/code_scanner.py
+++ b/cycode/cli/apps/scan/code_scanner.py
@@ -28,7 +28,6 @@ from cycode.cli.files_collector.sca import sca_code_scanner
 from cycode.cli.files_collector.sca.sca_code_scanner import perform_pre_scan_documents_actions
 from cycode.cli.files_collector.zip_documents import zip_documents
 from cycode.cli.models import CliError, Document, DocumentDetections, LocalScanResult
-from cycode.cli.printers import ConsolePrinter
 from cycode.cli.utils import scan_utils
 from cycode.cli.utils.git_proxy import git_proxy
 from cycode.cli.utils.path_utils import get_path_by_os
@@ -304,10 +303,11 @@ def scan_documents(
 ) -> None:
     scan_type = ctx.obj['scan_type']
     progress_bar = ctx.obj['progress_bar']
+    printer = ctx.obj.get('console_printer')
 
     if not documents_to_scan:
         progress_bar.stop()
-        ConsolePrinter(ctx).print_error(
+        printer.print_error(
             CliError(
                 code='no_relevant_files',
                 message='Error: The scan could not be completed - relevant files to scan are not found. '
@@ -569,7 +569,7 @@ def print_debug_scan_details(scan_details_response: 'ScanDetailsResponse') -> No
 def print_results(
     ctx: typer.Context, local_scan_results: List[LocalScanResult], errors: Optional[Dict[str, 'CliError']] = None
 ) -> None:
-    printer = ConsolePrinter(ctx)
+    printer = ctx.obj.get('console_printer')
     printer.print_scan_results(local_scan_results, errors)
 
 

--- a/cycode/cli/cli_types.py
+++ b/cycode/cli/cli_types.py
@@ -10,6 +10,12 @@ class OutputTypeOption(str, Enum):
     TABLE = 'table'
 
 
+class ExportTypeOption(str, Enum):
+    JSON = 'json'
+    HTML = 'html'
+    SVG = 'svg'
+
+
 class ScanTypeOption(str, Enum):
     SECRET = consts.SECRET_SCAN_TYPE
     SCA = consts.SCA_SCAN_TYPE

--- a/cycode/cli/exceptions/handle_errors.py
+++ b/cycode/cli/exceptions/handle_errors.py
@@ -4,14 +4,14 @@ import click
 import typer
 
 from cycode.cli.models import CliError, CliErrors
-from cycode.cli.printers import ConsolePrinter
 from cycode.cli.utils.sentry import capture_exception
 
 
 def handle_errors(
     ctx: typer.Context, err: BaseException, cli_errors: CliErrors, *, return_exception: bool = False
 ) -> Optional['CliError']:
-    ConsolePrinter(ctx).print_exception(err)
+    printer = ctx.obj.get('console_printer')
+    printer.print_exception(err)
 
     if type(err) in cli_errors:
         error = cli_errors[type(err)].enrich(additional_message=str(err))
@@ -22,7 +22,7 @@ def handle_errors(
         if return_exception:
             return error
 
-        ConsolePrinter(ctx).print_error(error)
+        printer.print_error(error)
         return None
 
     if isinstance(err, click.ClickException):
@@ -34,5 +34,5 @@ def handle_errors(
     if return_exception:
         return unknown_error
 
-    ConsolePrinter(ctx).print_error(unknown_error)
+    printer.print_error(unknown_error)
     raise typer.Exit(1)

--- a/cycode/cli/printers/json_printer.py
+++ b/cycode/cli/printers/json_printer.py
@@ -1,7 +1,6 @@
 import json
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-from cycode.cli.console import console
 from cycode.cli.models import CliError, CliResult
 from cycode.cli.printers.printer_base import PrinterBase
 from cycode.cyclient.models import DetectionSchema
@@ -14,12 +13,12 @@ class JsonPrinter(PrinterBase):
     def print_result(self, result: CliResult) -> None:
         result = {'result': result.success, 'message': result.message, 'data': result.data}
 
-        console.print_json(self.get_data_json(result))
+        self.console.print_json(self.get_data_json(result))
 
     def print_error(self, error: CliError) -> None:
         result = {'error': error.code, 'message': error.message}
 
-        console.print_json(self.get_data_json(result))
+        self.console.print_json(self.get_data_json(result))
 
     def print_scan_results(
         self, local_scan_results: List['LocalScanResult'], errors: Optional[Dict[str, 'CliError']] = None
@@ -46,7 +45,7 @@ class JsonPrinter(PrinterBase):
             # FIXME(MarshalX): we don't care about scan IDs in JSON output due to clumsy JSON root structure
             inlined_errors = [err._asdict() for err in errors.values()]
 
-        console.print_json(self._get_json_scan_result(scan_ids, detections_dict, report_urls, inlined_errors))
+        self.console.print_json(self._get_json_scan_result(scan_ids, detections_dict, report_urls, inlined_errors))
 
     def _get_json_scan_result(
         self, scan_ids: List[str], detections: dict, report_urls: List[str], errors: List[dict]

--- a/cycode/cli/printers/printer_base.py
+++ b/cycode/cli/printers/printer_base.py
@@ -4,11 +4,12 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 import typer
 
-from cycode.cli.console import console_err
 from cycode.cli.models import CliError, CliResult
 from cycode.cyclient.headers import get_correlation_id
 
 if TYPE_CHECKING:
+    from rich.console import Console
+
     from cycode.cli.models import LocalScanResult
 
 
@@ -24,8 +25,15 @@ class PrinterBase(ABC):
         'Please note that not all results may be available:[/]'
     )
 
-    def __init__(self, ctx: typer.Context) -> None:
+    def __init__(
+        self,
+        ctx: typer.Context,
+        console: 'Console',
+        console_err: 'Console',
+    ) -> None:
         self.ctx = ctx
+        self.console = console
+        self.console_err = console_err
 
     @abstractmethod
     def print_scan_results(
@@ -41,8 +49,7 @@ class PrinterBase(ABC):
     def print_error(self, error: CliError) -> None:
         pass
 
-    @staticmethod
-    def print_exception(e: Optional[BaseException] = None) -> None:
+    def print_exception(self, e: Optional[BaseException] = None) -> None:
         """We are printing it in stderr so, we don't care about supporting JSON and TABLE outputs.
 
         Note:
@@ -54,6 +61,6 @@ class PrinterBase(ABC):
             else RichTraceback.from_exception(*sys.exc_info())
         )
         rich_traceback.show_locals = False
-        console_err.print(rich_traceback)
+        self.console_err.print(rich_traceback)
 
-        console_err.print(f'[red]Correlation ID:[/] {get_correlation_id()}')
+        self.console_err.print(f'[red]Correlation ID:[/] {get_correlation_id()}')

--- a/cycode/cli/printers/rich_printer.py
+++ b/cycode/cli/printers/rich_printer.py
@@ -8,7 +8,6 @@ from rich.text import Text
 
 from cycode.cli import consts
 from cycode.cli.cli_types import SeverityOption
-from cycode.cli.console import console
 from cycode.cli.printers.text_printer import TextPrinter
 from cycode.cli.printers.utils.code_snippet_syntax import get_code_snippet_syntax
 from cycode.cli.printers.utils.detection_data import get_detection_title
@@ -24,7 +23,7 @@ class RichPrinter(TextPrinter):
         self, local_scan_results: List['LocalScanResult'], errors: Optional[Dict[str, 'CliError']] = None
     ) -> None:
         if not errors and all(result.issue_detected == 0 for result in local_scan_results):
-            console.print(self.NO_DETECTIONS_MESSAGE)
+            self.console.print(self.NO_DETECTIONS_MESSAGE)
             return
 
         current_file = None
@@ -44,14 +43,13 @@ class RichPrinter(TextPrinter):
 
         self.print_report_urls_and_errors(local_scan_results, errors)
 
-    @staticmethod
-    def _print_file_header(file_path: str) -> None:
+    def _print_file_header(self, file_path: str) -> None:
         clickable_path = f'[link=file://{file_path}]{file_path}[/link]'
         file_header = Panel(
             Text.from_markup(f'[b purple3]:file_folder: File: {clickable_path}[/]', justify='center'),
             border_style='dim',
         )
-        console.print(file_header)
+        self.console.print(file_header)
 
     def _get_details_table(self, detection: 'Detection') -> Table:
         details_table = Table(show_header=False, box=None, padding=(0, 1))
@@ -138,4 +136,4 @@ class RichPrinter(TextPrinter):
             title_align='center',
         )
 
-        console.print(violation_card_panel)
+        self.console.print(violation_card_panel)

--- a/cycode/cli/printers/tables/sca_table_printer.py
+++ b/cycode/cli/printers/tables/sca_table_printer.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List
 
 from cycode.cli.cli_types import SeverityOption
-from cycode.cli.console import console
 from cycode.cli.consts import LICENSE_COMPLIANCE_POLICY_ID, PACKAGE_VULNERABILITY_POLICY_ID
 from cycode.cli.models import Detection
 from cycode.cli.printers.tables.table import Table
@@ -129,9 +128,8 @@ class ScaTablePrinter(TablePrinterBase):
         table.add_cell(CVE_COLUMNS, detection_details.get('vulnerability_id'))
         table.add_cell(LICENSE_COLUMN, detection_details.get('license'))
 
-    @staticmethod
-    def _print_summary_issues(detections_count: int, title: str) -> None:
-        console.print(f':no_entry: Found {detections_count} issues of type: [b]{title}[/]')
+    def _print_summary_issues(self, detections_count: int, title: str) -> None:
+        self.console.print(f':no_entry: Found {detections_count} issues of type: [b]{title}[/]')
 
     @staticmethod
     def _extract_detections_per_policy_id(

--- a/cycode/cli/printers/tables/table_printer_base.py
+++ b/cycode/cli/printers/tables/table_printer_base.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 import typer
 
-from cycode.cli.console import console
 from cycode.cli.models import CliError, CliResult
 from cycode.cli.printers.printer_base import PrinterBase
 from cycode.cli.printers.text_printer import TextPrinter
@@ -14,8 +13,8 @@ if TYPE_CHECKING:
 
 
 class TablePrinterBase(PrinterBase, abc.ABC):
-    def __init__(self, ctx: typer.Context) -> None:
-        super().__init__(ctx)
+    def __init__(self, ctx: typer.Context, *args, **kwargs) -> None:
+        super().__init__(ctx, *args, **kwargs)
         self.scan_type: str = ctx.obj.get('scan_type')
         self.show_secret: bool = ctx.obj.get('show_secret', False)
 
@@ -29,7 +28,7 @@ class TablePrinterBase(PrinterBase, abc.ABC):
         self, local_scan_results: List['LocalScanResult'], errors: Optional[Dict[str, 'CliError']] = None
     ) -> None:
         if not errors and all(result.issue_detected == 0 for result in local_scan_results):
-            console.print(self.NO_DETECTIONS_MESSAGE)
+            self.console.print(self.NO_DETECTIONS_MESSAGE)
             return
 
         self._print_results(local_scan_results)
@@ -37,9 +36,9 @@ class TablePrinterBase(PrinterBase, abc.ABC):
         if not errors:
             return
 
-        console.print(self.FAILED_SCAN_MESSAGE)
+        self.console.print(self.FAILED_SCAN_MESSAGE)
         for scan_id, error in errors.items():
-            console.print(f'- {scan_id}: ', end='')
+            self.console.print(f'- {scan_id}: ', end='')
             self.print_error(error)
 
     def _is_git_repository(self) -> bool:
@@ -49,13 +48,12 @@ class TablePrinterBase(PrinterBase, abc.ABC):
     def _print_results(self, local_scan_results: List['LocalScanResult']) -> None:
         raise NotImplementedError
 
-    @staticmethod
-    def _print_table(table: 'Table') -> None:
+    def _print_table(self, table: 'Table') -> None:
         if table.get_rows():
-            console.print(table.get_table())
+            self.console.print(table.get_table())
 
-    @staticmethod
     def _print_report_urls(
+        self,
         local_scan_results: List['LocalScanResult'],
         aggregation_report_url: Optional[str] = None,
     ) -> None:
@@ -63,9 +61,9 @@ class TablePrinterBase(PrinterBase, abc.ABC):
         if not report_urls and not aggregation_report_url:
             return
         if aggregation_report_url:
-            console.print(f'Report URL: {aggregation_report_url}')
+            self.console.print(f'Report URL: {aggregation_report_url}')
             return
 
-        console.print('Report URLs:')
+        self.console.print('Report URLs:')
         for report_url in report_urls:
-            console.print(f'- {report_url}')
+            self.console.print(f'- {report_url}')

--- a/tests/cli/exceptions/test_handle_scan_errors.py
+++ b/tests/cli/exceptions/test_handle_scan_errors.py
@@ -10,6 +10,7 @@ from cycode.cli.cli_types import OutputTypeOption
 from cycode.cli.console import console_err
 from cycode.cli.exceptions import custom_exceptions
 from cycode.cli.exceptions.handle_scan_errors import handle_scan_exception
+from cycode.cli.printers import ConsolePrinter
 from cycode.cli.utils.git_proxy import git_proxy
 
 if TYPE_CHECKING:
@@ -18,7 +19,9 @@ if TYPE_CHECKING:
 
 @pytest.fixture()
 def ctx() -> typer.Context:
-    return typer.Context(click.Command('path'), obj={'verbose': False, 'output': OutputTypeOption.TEXT})
+    ctx = typer.Context(click.Command('path'), obj={'verbose': False, 'output': OutputTypeOption.TEXT})
+    ctx.obj['console_printer'] = ConsolePrinter(ctx)
+    return ctx
 
 
 @pytest.mark.parametrize(
@@ -60,6 +63,7 @@ def test_handle_exception_click_error(ctx: typer.Context) -> None:
 
 def test_handle_exception_verbose(monkeypatch: 'MonkeyPatch') -> None:
     ctx = typer.Context(click.Command('path'), obj={'verbose': True, 'output': OutputTypeOption.TEXT})
+    ctx.obj['console_printer'] = ConsolePrinter(ctx)
 
     error_text = 'test'
 


### PR DESCRIPTION
<img width="1788" alt="image" src="https://github.com/user-attachments/assets/d126bc54-d440-4550-9cbf-5fe43122ebbc" />

It supports all output types for HTML and SVG including rich (violation panels) and tables 😎 Also, it allows to show nice output in the terminal and export JSON to file at the same CLI run