### PR TITLE
CM-47699 - Fix Linux executable builds

### DIFF
--- a/.github/workflows/build_executable.yml
+++ b/.github/workflows/build_executable.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - CM-47699-fix-linux-executable-builds
 
 permissions:
   contents: write
@@ -15,10 +16,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-13, macos-14, windows-2019 ]
+        os: [ ubuntu-22.04, macos-13, macos-14, windows-2019 ]
         mode: [ 'onefile', 'onedir' ]
         exclude:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             mode: onedir
           - os: windows-2019
             mode: onedir
@@ -31,7 +32,7 @@ jobs:
 
     steps:
       - name: Run Cimon
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         uses: cycodelabs/cimon-action@v0
         with:
           client-id: ${{ secrets.CIMON_CLIENT_ID }}


### PR DESCRIPTION

Build on ubuntu-20.04 (onefile mode)
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
