### PR TITLE
CM-48457 - Fix Homebrew completions

### DIFF
--- a/cycode/cli/app.py
+++ b/cycode/cli/app.py
@@ -4,6 +4,7 @@ from typing import Annotated, Optional
 import typer
 from typer import rich_utils
 from typer._completion_classes import completion_init
+from typer._completion_shared import Shells
 from typer.completion import install_callback, show_callback
 
 from cycode import __version__
@@ -113,16 +114,17 @@ def app_callback(
         ),
     ] = False,
     __: Annotated[
-        Optional[bool],
+        Shells,  # the choice is required for Homebrew to be able to install the completion
         typer.Option(
             '--show-completion',
             callback=show_callback,
             is_eager=True,
             expose_value=False,
-            help='Show completion for the current shell, to copy it or customize the installation.',
+            show_default=False,
+            help='Show completion for the specified shell, to copy it or customize the installation.',
             rich_help_panel=_COMPLETION_RICH_HELP_PANEL,
         ),
-    ] = False,
+    ] = None,
 ) -> None:
     """[bold cyan]Cycode CLI - Command Line Interface for Cycode.[/]"""
     init_sentry()


### PR DESCRIPTION
Context: https://github.com/Homebrew/homebrew-core/pull/223454


Implementation of `generate_completions_from_executable`:  https://github.com/Homebrew/brew/blob/e4e75f547480accf95acff5aa954ad8855716df0/Library/Homebrew/formula.rb#L2117-L2167

So to be able to do work around using `generate_completions_from_executable(bin/"cycode", "--show-completion", shells: [:fish, :zsh])` we need to take the first argument as shell and not rely on `shellingham`

<img width="1222" alt="image" src="https://github.com/user-attachments/assets/62262688-80c4-4a6a-b09c-79124c00c5d4" />
<img width="736" alt="image" src="https://github.com/user-attachments/assets/0a280237-1180-45eb-afc9-80ac04d9e04d" />
