### PR TITLE
CM-51659 - Add customization of timeouts for dependency trees (SCA restore)

### DIFF
--- a/cycode/cli/files_collector/sca/maven/restore_gradle_dependencies.py
+++ b/cycode/cli/files_collector/sca/maven/restore_gradle_dependencies.py
@@ -12,7 +12,6 @@ from cycode.cli.utils.shell_executor import shell
 BUILD_GRADLE_FILE_NAME = 'build.gradle'
 BUILD_GRADLE_KTS_FILE_NAME = 'build.gradle.kts'
 BUILD_GRADLE_DEP_TREE_FILE_NAME = 'gradle-dependencies-generated.txt'
-BUILD_GRADLE_ALL_PROJECTS_TIMEOUT = 180
 BUILD_GRADLE_ALL_PROJECTS_COMMAND = ['gradle', 'projects']
 ALL_PROJECTS_REGEX = r"[+-]{3} Project '(.*?)'"
 
@@ -48,7 +47,7 @@ class RestoreGradleDependencies(BaseRestoreDependencies):
     def get_all_projects(self) -> set[str]:
         output = shell(
             command=BUILD_GRADLE_ALL_PROJECTS_COMMAND,
-            timeout=BUILD_GRADLE_ALL_PROJECTS_TIMEOUT,
+            timeout=self.command_timeout,
             working_directory=get_path_from_context(self.ctx),
         )
         if not output:

--- a/cycode/cli/files_collector/sca/sca_file_collector.py
+++ b/cycode/cli/files_collector/sca/sca_file_collector.py
@@ -1,3 +1,4 @@
+import os
 from typing import TYPE_CHECKING, Optional
 
 import typer
@@ -122,14 +123,15 @@ def _try_restore_dependencies(
 
 
 def _get_restore_handlers(ctx: typer.Context, is_git_diff: bool) -> list[BaseRestoreDependencies]:
+    build_dep_tree_timeout = int(os.getenv('CYCODE_BUILD_DEP_TREE_TIMEOUT_SECONDS', BUILD_DEP_TREE_TIMEOUT))
     return [
-        RestoreGradleDependencies(ctx, is_git_diff, BUILD_DEP_TREE_TIMEOUT),
-        RestoreMavenDependencies(ctx, is_git_diff, BUILD_DEP_TREE_TIMEOUT),
-        RestoreSbtDependencies(ctx, is_git_diff, BUILD_DEP_TREE_TIMEOUT),
-        RestoreGoDependencies(ctx, is_git_diff, BUILD_DEP_TREE_TIMEOUT),
-        RestoreNugetDependencies(ctx, is_git_diff, BUILD_DEP_TREE_TIMEOUT),
-        RestoreNpmDependencies(ctx, is_git_diff, BUILD_DEP_TREE_TIMEOUT),
-        RestoreRubyDependencies(ctx, is_git_diff, BUILD_DEP_TREE_TIMEOUT),
+        RestoreGradleDependencies(ctx, is_git_diff, build_dep_tree_timeout),
+        RestoreMavenDependencies(ctx, is_git_diff, build_dep_tree_timeout),
+        RestoreSbtDependencies(ctx, is_git_diff, build_dep_tree_timeout),
+        RestoreGoDependencies(ctx, is_git_diff, build_dep_tree_timeout),
+        RestoreNugetDependencies(ctx, is_git_diff, build_dep_tree_timeout),
+        RestoreNpmDependencies(ctx, is_git_diff, build_dep_tree_timeout),
+        RestoreRubyDependencies(ctx, is_git_diff, build_dep_tree_timeout),
     ]
 
 


### PR DESCRIPTION
* Added support for CLI to have customized timeout for building dependency trees, by trying to take environment value of `CYCODE_BUILD_DEP_TREE_TIMEOUT_SECONDS` and in case not set keep the default 180 seconds