### PR TITLE
CM-61550: Handle HTTP 408 with a user-friendly slow connection message

### DIFF
--- a/cycode/cli/exceptions/custom_exceptions.py
+++ b/cycode/cli/exceptions/custom_exceptions.py
@@ -55,6 +55,14 @@ class HttpUnauthorizedError(RequestHttpError):
         return f'HTTP unauthorized error occurred during the request. Message: {self.error_message}'
 
 
+class HttpRequestTimeoutError(RequestHttpError):
+    def __init__(self, error_message: str, response: Response) -> None:
+        super().__init__(408, error_message, response)
+
+    def __str__(self) -> str:
+        return f'HTTP request timeout error occurred during the request. Message: {self.error_message}'
+
+
 class ZipTooLargeError(CycodeError):
     def __init__(self, size_limit: int) -> None:
         self.size_limit = size_limit
@@ -92,6 +100,12 @@ KNOWN_USER_FRIENDLY_REQUEST_ERRORS: CliErrors = {
         soft_fail=True,
         code='timeout_error',
         message='The request timed out. Please try again by executing the `cycode scan` command',
+    ),
+    HttpRequestTimeoutError: CliError(
+        soft_fail=True,
+        code='request_timeout_error',
+        message='The scan upload timed out. This may be due to a slow connection. '
+        'Please try again by executing the `cycode scan` command',
     ),
     HttpUnauthorizedError: CliError(
         soft_fail=True,

--- a/cycode/cyclient/cycode_client_base.py
+++ b/cycode/cyclient/cycode_client_base.py
@@ -9,6 +9,7 @@ from requests.adapters import HTTPAdapter
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_random_exponential
 
 from cycode.cli.exceptions.custom_exceptions import (
+    HttpRequestTimeoutError,
     HttpUnauthorizedError,
     RequestConnectionError,
     RequestError,
@@ -184,5 +185,8 @@ class CycodeClientBase:
     def _get_http_exception(e: exceptions.HTTPError) -> RequestError:
         if e.response.status_code == 401:
             return HttpUnauthorizedError(e.response.text, e.response)
+
+        if e.response.status_code == 408:
+            return HttpRequestTimeoutError(e.response.text, e.response)
 
         return RequestHttpError(e.response.status_code, e.response.text, e.response)


### PR DESCRIPTION
Adds HttpRequestTimeoutError as a distinct subclass of RequestHttpError for 408 responses, so users see a specific message about slow connections instead of the generic "unable to complete scan" error.