### PR TITLE
CM-65507 fire AI Guardrails SessionStart hook on all sources (resume/fork)

### DIFF
--- a/cycode/cli/apps/ai_guardrails/ides/claude_code.py
+++ b/cycode/cli/apps/ai_guardrails/ides/claude_code.py
@@ -239,7 +239,6 @@ class ClaudeCode(IDE):
             'hooks': {
                 'SessionStart': [
                     {
-                        'matcher': 'startup|clear',
                         'hooks': [{'type': 'command', 'command': _SESSION_START_COMMAND}],
                     }
                 ],

--- a/cycode/cli/apps/ai_guardrails/ides/codex.py
+++ b/cycode/cli/apps/ai_guardrails/ides/codex.py
@@ -201,7 +201,6 @@ class Codex(IDE):
             'hooks': {
                 'SessionStart': [
                     {
-                        'matcher': 'startup|clear',
                         'hooks': [{'type': 'command', 'command': _SESSION_START_COMMAND}],
                     }
                 ],

--- a/tests/cli/commands/ai_guardrails/ides/test_codex.py
+++ b/tests/cli/commands/ai_guardrails/ides/test_codex.py
@@ -146,10 +146,11 @@ def test_settings_path_honors_codex_home_env(fs: FakeFilesystem, monkeypatch: py
 # --- hooks config rendering --------------------------------------------------
 
 
-def test_render_hooks_session_start_matcher_includes_clear() -> None:
-    """SessionStart must fire on /clear too (conversation_id rotates)."""
+def test_render_hooks_session_start_matches_all_sources() -> None:
+    """SessionStart must fire on every source (a forked session reports 'resume',
+    so no matcher is set -> match-all)."""
     rendered = Codex().render_hooks_config()
-    assert rendered['hooks']['SessionStart'][0]['matcher'] == 'startup|clear'
+    assert 'matcher' not in rendered['hooks']['SessionStart'][0]
     assert '--ide codex' in rendered['hooks']['SessionStart'][0]['hooks'][0]['command']
 
 

--- a/tests/cli/commands/ai_guardrails/test_hooks_manager.py
+++ b/tests/cli/commands/ai_guardrails/test_hooks_manager.py
@@ -111,11 +111,12 @@ def test_claude_code_render_hooks_async() -> None:
 
 
 def test_claude_code_render_hooks_session_start() -> None:
-    """Claude Code SessionStart fires on startup and /clear."""
+    """Claude Code SessionStart fires on every source (a forked session reports
+    'resume', so the matcher is empty -> match-all)."""
     config = ClaudeCode().render_hooks_config()
     entries = config['hooks']['SessionStart']
     assert len(entries) == 1
-    assert entries[0]['matcher'] == 'startup|clear'
+    assert 'matcher' not in entries[0]
     assert CYCODE_SESSION_START_COMMAND in entries[0]['hooks'][0]['command']
     assert '--ide claude-code' in entries[0]['hooks'][0]['command']
 


### PR DESCRIPTION
A forked Claude Code session reports its SessionStart source as 'resume', so the 'startup|clear' matcher skipped guardrails session-start for forked and resumed sessions. Omit the SessionStart matcher entirely (match-all) for both Claude Code and Codex so it fires on every source.