### PR TITLE
CM-65436: retry scan notification on 404 after presigned upload

### DIFF
--- a/cycode/cli/apps/scan/code_scanner.py
+++ b/cycode/cli/apps/scan/code_scanner.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 import requests
 import typer
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_random_exponential
 
 from cycode.cli import consts
 from cycode.cli.apps.scan.aggregation_report import try_set_aggregation_report_url_if_needed
@@ -22,6 +23,7 @@ from cycode.cli.exceptions.handle_scan_errors import handle_scan_exception
 from cycode.cli.files_collector.path_documents import get_relevant_documents
 from cycode.cli.files_collector.sca.sca_file_collector import add_sca_dependencies_tree_documents_if_needed
 from cycode.cli.files_collector.zip_documents import zip_documents
+from cycode.cli.exceptions.custom_exceptions import RequestHttpError
 from cycode.cli.models import CliError, Document, LocalScanResult
 from cycode.cli.utils.path_utils import get_absolute_path, get_path_by_os
 from cycode.cli.utils.progress_bar import ScanProgressBarSection
@@ -32,7 +34,7 @@ from cycode.cli.utils.scan_utils import (
     set_issue_detected_by_scan_results,
     should_use_presigned_upload,
 )
-from cycode.cyclient.models import ZippedFileScanResult
+from cycode.cyclient.models import ScanInitializationResponse, ZippedFileScanResult
 from cycode.logger import get_logger
 
 if TYPE_CHECKING:
@@ -295,6 +297,26 @@ def scan_documents(
     print_local_scan_results(ctx, local_scan_results, errors)
 
 
+@retry(
+    retry=retry_if_exception(lambda e: isinstance(e, RequestHttpError) and e.status_code == 404),
+    stop=stop_after_attempt(3),
+    wait=wait_random_exponential(multiplier=1, min=1, max=5),
+    reraise=True,
+)
+def _notify_scan_from_upload_id(
+    cycode_client: 'ScanClient',
+    scan_type: str,
+    upload_id: str,
+    zipped_documents: 'InMemoryZip',
+    scan_parameters: dict,
+    is_git_diff: bool,
+    is_commit_range: bool,
+) -> 'ScanInitializationResponse':
+    return cycode_client.scan_repository_from_upload_id(
+        scan_type, upload_id, zipped_documents, scan_parameters, is_git_diff, is_commit_range
+    )
+
+
 def _perform_scan_v4_async(
     cycode_client: 'ScanClient',
     zipped_documents: 'InMemoryZip',
@@ -312,8 +334,8 @@ def _perform_scan_v4_async(
     )
     logger.debug('Uploaded zip to presigned URL')
 
-    scan_async_result = cycode_client.scan_repository_from_upload_id(
-        scan_type, upload_link.upload_id, zipped_documents, scan_parameters, is_git_diff, is_commit_range
+    scan_async_result = _notify_scan_from_upload_id(
+        cycode_client, scan_type, upload_link.upload_id, zipped_documents, scan_parameters, is_git_diff, is_commit_range
     )
     logger.debug(
         'Presigned upload scan request triggered, %s',

--- a/cycode/cli/apps/scan/code_scanner.py
+++ b/cycode/cli/apps/scan/code_scanner.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 import requests
 import typer
-from tenacity import Retrying, retry_if_exception, stop_after_attempt, wait_random_exponential
 
 from cycode.cli import consts
 from cycode.cli.apps.scan.aggregation_report import try_set_aggregation_report_url_if_needed
@@ -19,7 +18,6 @@ from cycode.cli.apps.scan.scan_result import (
 )
 from cycode.cli.config import configuration_manager
 from cycode.cli.exceptions import custom_exceptions
-from cycode.cli.exceptions.custom_exceptions import RequestHttpError
 from cycode.cli.exceptions.handle_scan_errors import handle_scan_exception
 from cycode.cli.files_collector.path_documents import get_relevant_documents
 from cycode.cli.files_collector.sca.sca_file_collector import add_sca_dependencies_tree_documents_if_needed
@@ -314,16 +312,9 @@ def _perform_scan_v4_async(
     )
     logger.debug('Uploaded zip to presigned URL')
 
-    for attempt in Retrying(
-        retry=retry_if_exception(lambda e: isinstance(e, RequestHttpError) and e.status_code == 404),
-        stop=stop_after_attempt(3),
-        wait=wait_random_exponential(multiplier=1, min=1, max=5),
-        reraise=True,
-    ):
-        with attempt:
-            scan_async_result = cycode_client.scan_repository_from_upload_id(
-                scan_type, upload_link.upload_id, zipped_documents, scan_parameters, is_git_diff, is_commit_range
-            )
+    scan_async_result = cycode_client.scan_repository_from_upload_id(
+        scan_type, upload_link.upload_id, zipped_documents, scan_parameters, is_git_diff, is_commit_range
+    )
     logger.debug(
         'Presigned upload scan request triggered, %s',
         {'scan_id': scan_async_result.scan_id, 'upload_id': upload_link.upload_id},

--- a/cycode/cli/apps/scan/code_scanner.py
+++ b/cycode/cli/apps/scan/code_scanner.py
@@ -19,11 +19,11 @@ from cycode.cli.apps.scan.scan_result import (
 )
 from cycode.cli.config import configuration_manager
 from cycode.cli.exceptions import custom_exceptions
+from cycode.cli.exceptions.custom_exceptions import RequestHttpError
 from cycode.cli.exceptions.handle_scan_errors import handle_scan_exception
 from cycode.cli.files_collector.path_documents import get_relevant_documents
 from cycode.cli.files_collector.sca.sca_file_collector import add_sca_dependencies_tree_documents_if_needed
 from cycode.cli.files_collector.zip_documents import zip_documents
-from cycode.cli.exceptions.custom_exceptions import RequestHttpError
 from cycode.cli.models import CliError, Document, LocalScanResult
 from cycode.cli.utils.path_utils import get_absolute_path, get_path_by_os
 from cycode.cli.utils.progress_bar import ScanProgressBarSection

--- a/cycode/cli/apps/scan/code_scanner.py
+++ b/cycode/cli/apps/scan/code_scanner.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 import requests
 import typer
-from tenacity import retry, retry_if_exception, stop_after_attempt, wait_random_exponential
+from tenacity import Retrying, retry_if_exception, stop_after_attempt, wait_random_exponential
 
 from cycode.cli import consts
 from cycode.cli.apps.scan.aggregation_report import try_set_aggregation_report_url_if_needed
@@ -34,7 +34,7 @@ from cycode.cli.utils.scan_utils import (
     set_issue_detected_by_scan_results,
     should_use_presigned_upload,
 )
-from cycode.cyclient.models import ScanInitializationResponse, ZippedFileScanResult
+from cycode.cyclient.models import ZippedFileScanResult
 from cycode.logger import get_logger
 
 if TYPE_CHECKING:
@@ -297,26 +297,6 @@ def scan_documents(
     print_local_scan_results(ctx, local_scan_results, errors)
 
 
-@retry(
-    retry=retry_if_exception(lambda e: isinstance(e, RequestHttpError) and e.status_code == 404),
-    stop=stop_after_attempt(3),
-    wait=wait_random_exponential(multiplier=1, min=1, max=5),
-    reraise=True,
-)
-def _notify_scan_from_upload_id(
-    cycode_client: 'ScanClient',
-    scan_type: str,
-    upload_id: str,
-    zipped_documents: 'InMemoryZip',
-    scan_parameters: dict,
-    is_git_diff: bool,
-    is_commit_range: bool,
-) -> 'ScanInitializationResponse':
-    return cycode_client.scan_repository_from_upload_id(
-        scan_type, upload_id, zipped_documents, scan_parameters, is_git_diff, is_commit_range
-    )
-
-
 def _perform_scan_v4_async(
     cycode_client: 'ScanClient',
     zipped_documents: 'InMemoryZip',
@@ -334,9 +314,16 @@ def _perform_scan_v4_async(
     )
     logger.debug('Uploaded zip to presigned URL')
 
-    scan_async_result = _notify_scan_from_upload_id(
-        cycode_client, scan_type, upload_link.upload_id, zipped_documents, scan_parameters, is_git_diff, is_commit_range
-    )
+    for attempt in Retrying(
+        retry=retry_if_exception(lambda e: isinstance(e, RequestHttpError) and e.status_code == 404),
+        stop=stop_after_attempt(3),
+        wait=wait_random_exponential(multiplier=1, min=1, max=5),
+        reraise=True,
+    ):
+        with attempt:
+            scan_async_result = cycode_client.scan_repository_from_upload_id(
+                scan_type, upload_link.upload_id, zipped_documents, scan_parameters, is_git_diff, is_commit_range
+            )
     logger.debug(
         'Presigned upload scan request triggered, %s',
         {'scan_id': scan_async_result.scan_id, 'upload_id': upload_link.upload_id},

--- a/cycode/cyclient/scan_client.py
+++ b/cycode/cyclient/scan_client.py
@@ -167,6 +167,8 @@ class ScanClient:
                 raise SlowUploadConnectionError from e
             raise
 
+    # Ideally this retry would live in _execute (CycodeClientBase) so all callers benefit,
+    # but that requires making the retry predicate configurable per-call — a larger refactor.
     @retry(
         retry=retry_if_exception(lambda e: isinstance(e, RequestHttpError) and e.status_code == 404),
         stop=stop_after_attempt(3),

--- a/cycode/cyclient/scan_client.py
+++ b/cycode/cyclient/scan_client.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 import requests
 from requests import Response
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_random_exponential
 
 from cycode.cli import consts
 from cycode.cli.config import configuration_manager
@@ -166,6 +167,12 @@ class ScanClient:
                 raise SlowUploadConnectionError from e
             raise
 
+    @retry(
+        retry=retry_if_exception(lambda e: isinstance(e, RequestHttpError) and e.status_code == 404),
+        stop=stop_after_attempt(3),
+        wait=wait_random_exponential(multiplier=1, min=1, max=5),
+        reraise=True,
+    )
     def scan_repository_from_upload_id(
         self,
         scan_type: str,


### PR DESCRIPTION
## Summary
- After a successful S3 presigned POST, the scan service verifies the upload via an internal file service. A transient 403 from the file service's S3 client is silently mapped to `false`, causing the scan service to return 404 to the CLI.
- Added `_notify_scan_from_upload_id` — a targeted retry wrapper (up to 3 attempts, random exponential backoff 1–5s) exclusively around the `scan_repository_from_upload_id` call in `_perform_scan_v4_async`.
- No global retry logic is touched; the retry only fires on 404 for this one call.

## Jira
[CM-65436](https://cycode.atlassian.net/browse/CM-65436)

[CM-65436]: https://cycode.atlassian.net/browse/CM-65436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ