### PR TITLE
CM-65436: add SAST fallback ignore-extensions list

### DIFF
--- a/cycode/cli/consts.py
+++ b/cycode/cli/consts.py
@@ -53,6 +53,30 @@ SECRET_SCAN_FILE_EXTENSIONS_TO_IGNORE = (
     '.iso',
 )
 
+# Fallback block-list used for SAST only when the server does not return scannable extensions
+# (e.g. when the customer has custom rules, any text file is scannable). These are non-source
+# data formats that can slip past binary detection (the EICAR test file and ClamAV signature
+# databases are plain ASCII) and may be quarantined by object-storage antivirus after upload.
+SAST_SCAN_FILE_EXTENSIONS_TO_IGNORE = (
+    '.bin',
+    '.cvd',
+    '.cld',
+    '.cud',
+    '.hdb',
+    '.hsb',
+    '.mdb',
+    '.msb',
+    '.ndb',
+    '.ndu',
+    '.ldb',
+    '.ldu',
+    '.idb',
+    '.fp',
+    '.sfp',
+    '.ign',
+    '.ign2',
+)
+
 SCA_CONFIGURATION_SCAN_SUPPORTED_FILES = (  # keep in lowercase
     'cargo.lock',
     'cargo.toml',

--- a/cycode/cli/files_collector/file_excluder.py
+++ b/cycode/cli/files_collector/file_excluder.py
@@ -63,7 +63,10 @@ class Excluder:
         }
         self._non_scannable_extensions: dict[str, tuple[str, ...]] = {
             consts.SECRET_SCAN_TYPE: consts.SECRET_SCAN_FILE_EXTENSIONS_TO_IGNORE,
+            consts.SAST_SCAN_TYPE: consts.SAST_SCAN_FILE_EXTENSIONS_TO_IGNORE,
         }
+        # Tracks scan types for which the SAST fallback log has already been emitted (log once, not per file)
+        self._logged_sast_fallback = False
 
     def apply_scan_config(self, scan_type: str, scan_config: 'models.ScanConfiguration') -> None:
         if scan_config.scannable_extensions:
@@ -86,6 +89,11 @@ class Excluder:
 
         non_scannable_extensions = self._non_scannable_extensions.get(scan_type)
         if non_scannable_extensions:
+            # For SAST, reaching the block-list means the server returned no scannable extensions
+            # (e.g. custom rules, or no remote config). Log once so this is diagnosable.
+            if scan_type == consts.SAST_SCAN_TYPE and not self._logged_sast_fallback:
+                self._logged_sast_fallback = True
+                logger.debug('No scannable extensions provided for SAST; falling back to the built-in ignore list')
             return not filename.endswith(non_scannable_extensions)
 
         return True


### PR DESCRIPTION
## Summary
- When the server returns no scannable extensions for SAST (e.g. the customer has custom rules, so any text file is scannable), the CLI previously relied only on binary detection to filter files.
- Text-based non-source files — the EICAR test file (`.bin`) and ClamAV signature databases (`.ndb`) — slip past binary detection and get uploaded. Object-storage antivirus then quarantines the zip, so the scan service can't find the file and the scan fails with "Could not find uploaded file to scan".
- Adds a SAST fallback block-list (`SAST_SCAN_FILE_EXTENSIONS_TO_IGNORE`) used **only** when no server allow-list is present, plus a one-time debug log when the fallback is hit so this is diagnosable from logs.

## Notes
- When the server **does** return scannable extensions, the allow-list takes priority and this fallback is never consulted (verified locally).
- Minimal AV-trigger set: `.bin`, `.ndb`, and common ClamAV signature-DB formats.

## Jira
[CM-65436](https://cycode.atlassian.net/browse/CM-65436)

[CM-65436]: https://cycode.atlassian.net/browse/CM-65436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ