### PR TITLE
CM-67318: Warn when env vars override configured credentials

### DIFF
--- a/cycode/cli/apps/configure/configure_command.py
+++ b/cycode/cli/apps/configure/configure_command.py
@@ -1,7 +1,12 @@
 from typing import Optional
 
 from cycode.cli.apps.configure.consts import CONFIGURATION_MANAGER, CREDENTIALS_MANAGER
-from cycode.cli.apps.configure.messages import get_credentials_update_result_message, get_urls_update_result_message
+from cycode.cli.apps.configure.messages import (
+    get_credentials_environment_variables_override_warning,
+    get_credentials_update_result_message,
+    get_urls_environment_variables_override_warning,
+    get_urls_update_result_message,
+)
 from cycode.cli.apps.configure.prompts import (
     get_api_url_input,
     get_app_url_input,
@@ -73,3 +78,14 @@ def configure_command() -> None:
         console.print(get_urls_update_result_message())
     if credentials_updated or oidc_credentials_updated:
         console.print(get_credentials_update_result_message())
+
+    # Warn about environment variables that override the configured file values, regardless of whether anything was
+    # updated. The env vars take precedence on every subsequent call, so configuring the file alone has no effect while
+    # they are set.
+    urls_override_warning = get_urls_environment_variables_override_warning()
+    if urls_override_warning:
+        console.print(f'[yellow]Warning:[/] {urls_override_warning}')
+
+    credentials_override_warning = get_credentials_environment_variables_override_warning()
+    if credentials_override_warning:
+        console.print(f'[yellow]Warning:[/] {credentials_override_warning}')

--- a/cycode/cli/apps/configure/messages.py
+++ b/cycode/cli/apps/configure/messages.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from cycode.cli.apps.configure.consts import (
     CONFIGURATION_MANAGER,
     CREDENTIALS_ARE_SET_IN_ENVIRONMENT_VARIABLES_MESSAGE,
@@ -14,11 +16,14 @@ def _are_credentials_exist_in_environment_variables() -> bool:
 
 
 def get_credentials_update_result_message() -> str:
-    success_message = CREDENTIALS_UPDATED_SUCCESSFULLY_MESSAGE.format(filename=CREDENTIALS_MANAGER.get_filename())
-    if _are_credentials_exist_in_environment_variables():
-        return f'{success_message}. {CREDENTIALS_ARE_SET_IN_ENVIRONMENT_VARIABLES_MESSAGE}'
+    return CREDENTIALS_UPDATED_SUCCESSFULLY_MESSAGE.format(filename=CREDENTIALS_MANAGER.get_filename())
 
-    return success_message
+
+def get_credentials_environment_variables_override_warning() -> Optional[str]:
+    if _are_credentials_exist_in_environment_variables():
+        return CREDENTIALS_ARE_SET_IN_ENVIRONMENT_VARIABLES_MESSAGE
+
+    return None
 
 
 def _are_urls_exist_in_environment_variables() -> bool:
@@ -28,10 +33,13 @@ def _are_urls_exist_in_environment_variables() -> bool:
 
 
 def get_urls_update_result_message() -> str:
-    success_message = URLS_UPDATED_SUCCESSFULLY_MESSAGE.format(
+    return URLS_UPDATED_SUCCESSFULLY_MESSAGE.format(
         filename=CONFIGURATION_MANAGER.global_config_file_manager.get_filename()
     )
-    if _are_urls_exist_in_environment_variables():
-        return f'{success_message}. {URLS_ARE_SET_IN_ENVIRONMENT_VARIABLES_MESSAGE}'
 
-    return success_message
+
+def get_urls_environment_variables_override_warning() -> Optional[str]:
+    if _are_urls_exist_in_environment_variables():
+        return URLS_ARE_SET_IN_ENVIRONMENT_VARIABLES_MESSAGE
+
+    return None

--- a/tests/cli/commands/configure/test_messages.py
+++ b/tests/cli/commands/configure/test_messages.py
@@ -1,0 +1,28 @@
+from typing import TYPE_CHECKING
+
+from cycode.cli.apps.configure import messages
+from cycode.cli.config import CYCODE_CLIENT_ID_ENV_VAR_NAME, CYCODE_CLIENT_SECRET_ENV_VAR_NAME
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_credentials_override_warning_absent_when_no_env_vars(monkeypatch: 'pytest.MonkeyPatch') -> None:
+    monkeypatch.delenv(CYCODE_CLIENT_ID_ENV_VAR_NAME, raising=False)
+    monkeypatch.delenv(CYCODE_CLIENT_SECRET_ENV_VAR_NAME, raising=False)
+
+    assert messages.get_credentials_environment_variables_override_warning() is None
+
+
+def test_credentials_override_warning_present_when_only_client_id_set(monkeypatch: 'pytest.MonkeyPatch') -> None:
+    monkeypatch.setenv(CYCODE_CLIENT_ID_ENV_VAR_NAME, 'env-client-id')
+    monkeypatch.delenv(CYCODE_CLIENT_SECRET_ENV_VAR_NAME, raising=False)
+
+    assert messages.get_credentials_environment_variables_override_warning() is not None
+
+
+def test_credentials_success_message_does_not_embed_override_warning(monkeypatch: 'pytest.MonkeyPatch') -> None:
+    monkeypatch.setenv(CYCODE_CLIENT_ID_ENV_VAR_NAME, 'env-client-id')
+    monkeypatch.setenv(CYCODE_CLIENT_SECRET_ENV_VAR_NAME, 'env-client-secret')
+
+    assert 'environment variables' not in messages.get_credentials_update_result_message()


### PR DESCRIPTION
## Summary
- `cycode configure` writes credentials to `~/.cycode/credentials.yaml`, but `CYCODE_CLIENT_ID`/`CYCODE_CLIENT_SECRET` (and the API/APP URL env vars) take precedence on every subsequent call. The override notice was previously only appended to the success message when a value actually changed, so a stale env var could silently shadow freshly configured credentials with no warning.
- Split the env-var override notice out of the success messages into dedicated helpers (`get_credentials_environment_variables_override_warning` / `get_urls_environment_variables_override_warning`).
- `configure` now prints these as `Warning:` lines whenever the relevant env vars are set — regardless of whether anything was updated (also covers the partial case where only the client id is set).
- Env-over-file precedence is intentional (CI/CD), so it is unchanged; this only adds the missing warning.
- Added `tests/cli/commands/configure/test_messages.py` covering the new helpers.

## Jira
[CM-67318](https://cycode.atlassian.net/browse/CM-67318)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CM-67318]: https://cycode.atlassian.net/browse/CM-67318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ